### PR TITLE
En6 157 mismatch between app builder and component manager job report

### DIFF
--- a/src/main/java/org/entando/kubernetes/model/digitalexchange/DigitalExchangeJob.java
+++ b/src/main/java/org/entando/kubernetes/model/digitalexchange/DigitalExchangeJob.java
@@ -14,6 +14,8 @@
 package org.entando.kubernetes.model.digitalexchange;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.entando.kubernetes.service.digitalexchange.model.DigitalExchange;
@@ -65,6 +67,7 @@ public class DigitalExchangeJob {
     private double progress;
 
     @Column(name = "status")
+    @Enumerated(EnumType.STRING)
     private JobStatus status;
 
     @PrePersist

--- a/src/main/java/org/entando/kubernetes/model/digitalexchange/DigitalExchangeJobComponent.java
+++ b/src/main/java/org/entando/kubernetes/model/digitalexchange/DigitalExchangeJobComponent.java
@@ -1,5 +1,7 @@
 package org.entando.kubernetes.model.digitalexchange;
 
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -27,6 +29,7 @@ public class DigitalExchangeJobComponent {
     private DigitalExchangeJob job;
 
     @Column(name = "component_type")
+    @Enumerated(EnumType.STRING)
     private ComponentType componentType;
 
     @Column(name = "name")
@@ -39,6 +42,7 @@ public class DigitalExchangeJobComponent {
     private String checksum;
 
     @Column(name = "status")
+    @Enumerated(EnumType.STRING)
     private JobStatus status;
 
     // metadata?

--- a/src/main/java/org/entando/kubernetes/model/digitalexchange/InstallableInstallResult.java
+++ b/src/main/java/org/entando/kubernetes/model/digitalexchange/InstallableInstallResult.java
@@ -1,0 +1,36 @@
+package org.entando.kubernetes.model.digitalexchange;
+
+import org.entando.kubernetes.service.digitalexchange.installable.Installable;
+
+public class InstallableInstallResult {
+
+    private Installable installable;
+    private JobStatus jobStatus;
+    private Exception exception;
+
+    public InstallableInstallResult(Installable installable, JobStatus jobStatus, Exception exception) {
+        this.installable = installable;
+        this.jobStatus = jobStatus;
+        this.exception = exception;
+    }
+
+    public InstallableInstallResult(Installable installable, JobStatus jobStatus) {
+        this(installable, jobStatus, null);
+    }
+
+    public Installable getInstallable() {
+        return installable;
+    }
+
+    public JobStatus getJobStatus() {
+        return jobStatus;
+    }
+
+    public Exception getException() {
+        return exception;
+    }
+
+    public boolean hasException() {
+        return this.exception != null;
+    }
+}

--- a/src/main/java/org/entando/kubernetes/model/digitalexchange/JobStatus.java
+++ b/src/main/java/org/entando/kubernetes/model/digitalexchange/JobStatus.java
@@ -14,13 +14,14 @@
 package org.entando.kubernetes.model.digitalexchange;
 
 public enum JobStatus {
-    
-    CREATED,
-    IN_PROGRESS,
-    COMPLETED,
-    ERROR,
 
-    UNINSTALLING,
-    ERROR_UNINSTALLING,
-    UNINSTALLED
+    INSTALL_CREATED,
+    INSTALL_IN_PROGRESS,
+    INSTALL_COMPLETED,
+    INSTALL_ERROR,
+
+    UNINSTALL_CREATED,
+    UNINSTALL_IN_PROGRESS,
+    UNINSTALL_ERROR,
+    UNINSTALL_COMPLETED
 }

--- a/src/main/java/org/entando/kubernetes/service/digitalexchange/DigitalExchangeInstallService.java
+++ b/src/main/java/org/entando/kubernetes/service/digitalexchange/DigitalExchangeInstallService.java
@@ -1,6 +1,7 @@
 package org.entando.kubernetes.service.digitalexchange;
 
 import java.util.concurrent.ExecutionException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.entando.kubernetes.controller.digitalexchange.component.DigitalExchangeComponent;
@@ -58,8 +59,6 @@ public class DigitalExchangeInstallService implements ApplicationContextAware {
     private final DigitalExchangesClient client;
     private final DigitalExchangeJobRepository jobRepository;
     private final DigitalExchangeJobComponentRepository componentRepository;
-
-
 
     private Collection<ComponentProcessor> componentProcessors = new ArrayList<>();
 
@@ -171,8 +170,6 @@ public class DigitalExchangeInstallService implements ApplicationContextAware {
                 try {
                     Thread.sleep(1000);
                 } catch (InterruptedException e) { e.printStackTrace(); }
-
-                jobRepository.updateJobStatus(job.getId(), JobStatus.IN_PROGRESS);
 
                 final CompletableFuture[] completableFutures = installables.stream().map(installable -> {
                     final DigitalExchangeJobComponent component = installable.getComponent();

--- a/src/main/java/org/entando/kubernetes/service/digitalexchange/DigitalExchangeInstallService.java
+++ b/src/main/java/org/entando/kubernetes/service/digitalexchange/DigitalExchangeInstallService.java
@@ -1,7 +1,7 @@
 package org.entando.kubernetes.service.digitalexchange;
 
-import java.util.concurrent.ExecutionException;
-import lombok.RequiredArgsConstructor;
+import java.nio.file.StandardCopyOption;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.entando.kubernetes.controller.digitalexchange.component.DigitalExchangeComponent;
@@ -30,14 +30,11 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.HttpClientErrorException;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -109,135 +106,106 @@ public class DigitalExchangeInstallService implements ApplicationContextAware {
     }
 
     private void install(final DigitalExchangeJob job, final DigitalExchange digitalExchange, final DigitalExchangeComponent component) {
-        Path tempZipPath = null;
 
-        try {
-            jobRepository.updateJobStatus(job.getId(), JobStatus.IN_PROGRESS);
+        jobRepository.updateJobStatus(job.getId(), JobStatus.IN_PROGRESS);
 
-            tempZipPath = Files.createTempFile(component.getId(), "");
+        getComponentPackageStream(digitalExchange, component)
+                .thenApply(packageStream -> createComponentLocalFile(component, packageStream))
+                .thenApply(packageLocalPath -> {
+                    if (StringUtils.isNotEmpty(job.getDigitalExchange().getPublicKey())) {
+                        verifyDownloadedContentSignature(packageLocalPath, digitalExchange, component);
+                    }
+                    return packageLocalPath;
+                })
+                .thenApply(packageLocalPath -> extractInstallableFromZip(job, packageLocalPath))
+                .thenAccept(installableList -> processAllInstallable(job, installableList))
+                .thenApply(this::handleInstallationSuccess)
+                .exceptionally(this::handleInstallationFailure)
+                .thenAccept(jobStatus -> jobRepository.updateJobStatus(job.getId(), jobStatus));
 
-            final DigitalExchangeBaseCall<InputStream> call = new DigitalExchangeBaseCall<>(
+    }
+
+
+    private CompletableFuture<InputStream> getComponentPackageStream(DigitalExchange digitalExchange, DigitalExchangeComponent component) {
+        return CompletableFuture.supplyAsync(() -> {
+            DigitalExchangeBaseCall<InputStream> call = new DigitalExchangeBaseCall<>(
                     HttpMethod.GET, "digitalExchange", "components", component.getId(), "package");
+            return  client.getStreamResponse(digitalExchange, call);
+        });
+    }
 
-            try (final InputStream in = client.getStreamResponse(digitalExchange, call)) {
-                Files.copy(in, tempZipPath, StandardCopyOption.REPLACE_EXISTING);
-            }
-
-            if (StringUtils.isNotEmpty(job.getDigitalExchange().getPublicKey())) {
-                verifyDownloadedContentSignature(tempZipPath, digitalExchange, component);
-            }
-
-            extractZip(job, tempZipPath);
-        } catch (SignatureMatchingException ex) {
-            jobRepository.updateJobStatus(job.getId(), JobStatus.ERROR);
-            log.error("Component signature doesn't match public key", ex);
-            throw new JobExecutionException("Unable to verify component signature", ex);
-        } catch (IOException | UncheckedIOException ex) {
-            jobRepository.updateJobStatus(job.getId(), JobStatus.ERROR);
-            log.error("Error while downloading component", ex);
-            throw new JobExecutionException("Unable to save component", ex);
-        } finally {
-            if (tempZipPath != null && !tempZipPath.toFile().delete()) {
-                log.warn("Unable to delete temporary zip file {}", tempZipPath.toFile().getAbsolutePath());
-            }
+    private Path createComponentLocalFile(DigitalExchangeComponent component, InputStream packageStream) {
+        Path tempPath = null;
+        try {
+            tempPath = Files.createTempFile(component.getId(), "");
+            Files.copy(packageStream, tempPath, StandardCopyOption.REPLACE_EXISTING);
+            return tempPath;
+        } catch (IOException e) {
+           throw new JobExecutionException("An error occurred while copying the package stream locally", e, tempPath);
         }
     }
 
     private void verifyDownloadedContentSignature(
-            final Path tempZipPath, final DigitalExchange digitalExchange,
-            final DigitalExchangeComponent component) throws IOException {
+            final Path tempPath, final DigitalExchange digitalExchange,
+            final DigitalExchangeComponent component) {
 
-        try (final InputStream in = Files.newInputStream(tempZipPath, StandardOpenOption.READ)) {
+        try (final InputStream in = Files.newInputStream(tempPath, StandardOpenOption.READ)) {
             final boolean signatureMatches = SignatureUtil.verifySignature(
                     in, SignatureUtil.publicKeyFromPEM(digitalExchange.getPublicKey()),
                     component.getSignature());
             if (!signatureMatches) {
                 throw new SignatureMatchingException("Component signature not matching public key");
             }
+        } catch (IOException e) {
+            throw new JobExecutionException("An error occurred while copying the package stream locally", e, tempPath);
         }
     }
 
-    private void extractZip(final DigitalExchangeJob job, final Path tempZipPath) {
-        log.info("Processing DEPKG File");
-        try (ZipFile zip = new ZipFile(tempZipPath.toFile())) {
+    private List<Installable> extractInstallableFromZip(DigitalExchangeJob job, Path tempPath) {
+        try (ZipFile zip = new ZipFile(tempPath.toFile())) {
             ZipReader zipReader = new ZipReader(zip);
             ComponentDescriptor descriptor = zipReader.readDescriptorFile("descriptor.yaml", ComponentDescriptor.class);
-            List<Installable> installables = getInstallables(job, zipReader, descriptor);
-
-            installables.forEach(installable -> installable.setComponent(persistComponent(job, installable)));
-
-            new Thread(() -> {
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) { e.printStackTrace(); }
-
-                final CompletableFuture[] completableFutures = installables.stream().map(installable -> {
-                    final DigitalExchangeJobComponent component = installable.getComponent();
-                    componentRepository.updateJobStatus(component.getId(), JobStatus.IN_PROGRESS);
-
-                    final CompletableFuture<?> future = installable.install();
-                    try {
-                        future.get();
-                        log.info("Installable '{}' finished successfully", installable.getName());
-                        componentRepository.updateJobStatus(component.getId(), JobStatus.COMPLETED);
-                    } catch (InterruptedException | ExecutionException ex) {
-                        log.error("Installable '{}' has errors", installable.getName(), ex);
-                        component.setStatus(JobStatus.ERROR);
-
-                        if (ex.getCause() != null) {
-                            String message = ex.getCause().getMessage();
-                            if (ex.getCause() instanceof HttpClientErrorException) {
-                                final HttpClientErrorException httpException = (HttpClientErrorException) ex.getCause();
-                                message = httpException.getMessage() + "\n" + httpException.getResponseBodyAsString();
-                            }
-                            componentRepository.updateJobStatus(component.getId(), JobStatus.ERROR, message);
-                        } else {
-                            componentRepository.updateJobStatus(component.getId(), JobStatus.ERROR, ex.getMessage());
-                        }
-                    }
-
-                    return future;
-                }).toArray(CompletableFuture[]::new);
-                CompletableFuture.allOf(completableFutures).whenComplete((object, ex) -> {
-                    final JobStatus status = ex == null ? JobStatus.COMPLETED : JobStatus.ERROR;
-                    jobRepository.updateJobStatus(job.getId(), status);
-                });
-            }).start();
-
-            log.info("Finished processing. Have a nice day!");
-            // add labels, etc
-        } catch (IOException ex) {
-            log.error("Error while extracting zip file", ex);
-            throw new JobExecutionException("Unable to extract zip file", ex);
+            return getInstallables(job, zipReader, descriptor);
+        } catch (IOException e) {
+            throw new JobExecutionException("Unable to extract the installables from the zip file", e, tempPath);
         }
+    }
 
+    private void processAllInstallable(DigitalExchangeJob job, List<Installable> installableList) {
+        installableList.forEach(installable -> installable.setComponent(persistComponent(job, installable)));
+
+        List<CompletableFuture> cfl = installableList.stream()
+                .peek(i ->  componentRepository.updateJobStatus(i.getComponent().getId(), JobStatus.IN_PROGRESS))
+                .map(Installable::install)
+                .map(cf -> cf.thenAcceptAsync(o -> {
+                    InstallableInstallResult iir = (InstallableInstallResult) o; // Required for type erasure
+                    componentRepository.updateJobStatus(iir.getInstallable().getComponent().getId(), JobStatus.COMPLETED);
+                }))
+                .collect(Collectors.toList());
+
+        CompletableFuture
+                .allOf(cfl.toArray(new CompletableFuture[]{}))
+                .thenRun(() -> log.info("Finished processing. Have a nice day!"))
+                .exceptionally(ex -> {
+                    log.error("Error while extracting zip file", ex);
+                    throw new JobExecutionException("An error occurred while installing components", ex);
+                });
 
     }
 
-    private CompletableFuture<InstallableInstallResult> updateDigitalExchangeComponentJobEntry(InstallableInstallResult result) {
-        if (result.hasException()) {
-            log.error("Installable '{}' has errors", result.getInstallable().getName(),
-                    result.getException());
-            result.getInstallable().getComponent().setStatus(JobStatus.ERROR);
-
-            if (result.getException().getCause() != null) {
-                String message = result.getException().getCause().getMessage();
-                if (result.getException().getCause() instanceof HttpClientErrorException) {
-                    final HttpClientErrorException httpException = (HttpClientErrorException) result.getException()
-                            .getCause();
-                    message = httpException.getMessage() + "\n" + httpException.getResponseBodyAsString();
-                }
-                componentRepository.updateJobStatus(result.getInstallable().getComponent().getId(), JobStatus.ERROR, message);
-            } else {
-                componentRepository.updateJobStatus(result.getInstallable().getComponent().getId(), JobStatus.ERROR, result.getException()
-                        .getMessage());
+    private JobStatus handleInstallationFailure(Throwable ex) {
+        log.error("An error occurred while processing the digital-exchange package", ex);
+        if (ex instanceof JobExecutionException) {
+            JobExecutionException e = (JobExecutionException) ex;
+            if (e.getJobAssociatedTempPath() != null && !e.getJobAssociatedTempPath().toFile().delete()) {
+                log.warn("Unable to delete temporary zip file {}", e.getJobAssociatedTempPath().toFile().getAbsolutePath());
             }
-        } else {
-            log.info("Installable '{}' finished successfully", result.getInstallable().getName());
-            componentRepository.updateJobStatus(result.getInstallable().getComponent().getId(), JobStatus.COMPLETED);
         }
+        return JobStatus.ERROR;
+    }
 
-        return CompletableFuture.completedFuture(result);
+    private JobStatus handleInstallationSuccess(Void any) {
+        return JobStatus.COMPLETED;
     }
 
     private List<Installable> getInstallables(final DigitalExchangeJob job, final ZipReader zipReader,

--- a/src/main/java/org/entando/kubernetes/service/digitalexchange/installable/Installable.java
+++ b/src/main/java/org/entando/kubernetes/service/digitalexchange/installable/Installable.java
@@ -64,9 +64,9 @@ public abstract class Installable<T> {
         InstallableInstallResult result;
         try {
             runnable.run();
-            result = new InstallableInstallResult(this, JobStatus.COMPLETED);
+            result = new InstallableInstallResult(this, JobStatus.INSTALL_COMPLETED);
         } catch (Exception e) {
-            result = new InstallableInstallResult(this, JobStatus.ERROR, e);
+            result = new InstallableInstallResult(this, JobStatus.INSTALL_ERROR, e);
         }
         return result;
     }

--- a/src/main/java/org/entando/kubernetes/service/digitalexchange/installable/Installable.java
+++ b/src/main/java/org/entando/kubernetes/service/digitalexchange/installable/Installable.java
@@ -8,6 +8,8 @@ import org.entando.kubernetes.model.digitalexchange.ComponentType;
 import org.entando.kubernetes.model.digitalexchange.DigitalExchangeJobComponent;
 
 import java.util.concurrent.CompletableFuture;
+import org.entando.kubernetes.model.digitalexchange.InstallableInstallResult;
+import org.entando.kubernetes.model.digitalexchange.JobStatus;
 
 /**
  * This class will represent something that can be installed on Entando
@@ -33,7 +35,7 @@ public abstract class Installable<T> {
      * This method will be called when every component was validated on the Digital Exchange bundle file
      * @return should return a CompletableFuture with its processing inside. It can be run asynchronously or not.
      */
-    public abstract CompletableFuture install();
+    public abstract CompletableFuture<InstallableInstallResult> install();
 
     /**
      * Should return the component type to understand what to do in case of a rollback
@@ -56,6 +58,17 @@ public abstract class Installable<T> {
             log.error("Problem while processing checksum", e);
         }
         return null;
+    }
+
+    protected InstallableInstallResult wrap(Runnable runnable) {
+        InstallableInstallResult result;
+        try {
+            runnable.run();
+            result = new InstallableInstallResult(this, JobStatus.COMPLETED);
+        } catch (Exception e) {
+            result = new InstallableInstallResult(this, JobStatus.ERROR, e);
+        }
+        return result;
     }
 
     public DigitalExchangeJobComponent getComponent() {

--- a/src/main/java/org/entando/kubernetes/service/digitalexchange/installable/processors/AssetProcessor.java
+++ b/src/main/java/org/entando/kubernetes/service/digitalexchange/installable/processors/AssetProcessor.java
@@ -1,11 +1,16 @@
 package org.entando.kubernetes.service.digitalexchange.installable.processors;
 
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.entando.kubernetes.model.digitalexchange.ComponentType;
 import org.entando.kubernetes.model.digitalexchange.DigitalExchangeJob;
 import org.entando.kubernetes.model.digitalexchange.DigitalExchangeJobComponent;
+import org.entando.kubernetes.model.digitalexchange.InstallableInstallResult;
 import org.entando.kubernetes.service.digitalexchange.DigitalExchangeUninstallService;
 import org.entando.kubernetes.service.digitalexchange.entandocore.EntandoEngineService;
 import org.entando.kubernetes.service.digitalexchange.installable.ComponentProcessor;
@@ -15,15 +20,9 @@ import org.entando.kubernetes.service.digitalexchange.job.model.ComponentDescrip
 import org.entando.kubernetes.service.digitalexchange.job.model.FileDescriptor;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-
 /**
- * Processor to handle Static files to be stored by Entando.
- * Commonly used for js, images and css.
- *
+ * Processor to handle Static files to be stored by Entando. Commonly used for js, images and css.
+ * <p>
  * This processor will also create the folders.
  *
  * @author Sergio Marcelino
@@ -37,7 +36,7 @@ public class AssetProcessor implements ComponentProcessor {
 
     @Override
     public List<? extends Installable> process(final DigitalExchangeJob job, final ZipReader zipReader,
-                                               final ComponentDescriptor descriptor) throws IOException {
+            final ComponentDescriptor descriptor) throws IOException {
 
         final List<Installable> installables = new LinkedList<>();
 
@@ -66,6 +65,7 @@ public class AssetProcessor implements ComponentProcessor {
 
     /**
      * This process will be hard coded in the {@link DigitalExchangeUninstallService}
+     *
      * @param componentType The component type being processed
      * @return always false
      */
@@ -86,10 +86,10 @@ public class AssetProcessor implements ComponentProcessor {
         }
 
         @Override
-        public CompletableFuture install() {
-            return CompletableFuture.runAsync(() -> {
+        public CompletableFuture<InstallableInstallResult> install() {
+            return CompletableFuture.supplyAsync(() -> {
                 log.info("Uploading file {}", representation.getFilename());
-                engineService.uploadFile(representation);
+                return wrap(() -> engineService.uploadFile(representation));
             });
         }
 
@@ -112,10 +112,10 @@ public class AssetProcessor implements ComponentProcessor {
         }
 
         @Override
-        public CompletableFuture install() {
-            return CompletableFuture.runAsync(() -> {
+        public CompletableFuture<InstallableInstallResult> install() {
+            return CompletableFuture.supplyAsync(() -> {
                 log.info("Creating directory {}", representation);
-                engineService.createFolder(representation);
+                return wrap(() -> engineService.createFolder(representation));
             });
         }
 

--- a/src/main/java/org/entando/kubernetes/service/digitalexchange/installable/processors/LabelProcessor.java
+++ b/src/main/java/org/entando/kubernetes/service/digitalexchange/installable/processors/LabelProcessor.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.entando.kubernetes.model.digitalexchange.ComponentType;
 import org.entando.kubernetes.model.digitalexchange.DigitalExchangeJob;
 import org.entando.kubernetes.model.digitalexchange.DigitalExchangeJobComponent;
+import org.entando.kubernetes.model.digitalexchange.InstallableInstallResult;
 import org.entando.kubernetes.service.digitalexchange.entandocore.EntandoEngineService;
 import org.entando.kubernetes.service.digitalexchange.installable.ComponentProcessor;
 import org.entando.kubernetes.service.digitalexchange.installable.Installable;
@@ -68,10 +69,10 @@ public class LabelProcessor implements ComponentProcessor {
         }
 
         @Override
-        public CompletableFuture install() {
-            return CompletableFuture.runAsync(() -> {
+        public CompletableFuture<InstallableInstallResult> install() {
+            return CompletableFuture.supplyAsync(() -> {
                 log.info("Registering Label {}", representation.getKey());
-                engineService.registerLabel(representation);
+                return wrap(() ->engineService.registerLabel(representation));
             });
         }
 

--- a/src/main/java/org/entando/kubernetes/service/digitalexchange/installable/processors/PageModelProcessor.java
+++ b/src/main/java/org/entando/kubernetes/service/digitalexchange/installable/processors/PageModelProcessor.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.entando.kubernetes.model.digitalexchange.ComponentType;
 import org.entando.kubernetes.model.digitalexchange.DigitalExchangeJob;
 import org.entando.kubernetes.model.digitalexchange.DigitalExchangeJobComponent;
+import org.entando.kubernetes.model.digitalexchange.InstallableInstallResult;
 import org.entando.kubernetes.service.digitalexchange.entandocore.EntandoEngineService;
 import org.entando.kubernetes.service.digitalexchange.installable.ComponentProcessor;
 import org.entando.kubernetes.service.digitalexchange.installable.Installable;
@@ -73,10 +74,10 @@ public class PageModelProcessor implements ComponentProcessor {
         }
 
         @Override
-        public CompletableFuture install() {
-            return CompletableFuture.runAsync(() -> {
+        public CompletableFuture<InstallableInstallResult> install() {
+            return CompletableFuture.supplyAsync(() -> {
                 log.info("Registering Page Model {}", representation.getCode());
-                engineService.registerPageModel(representation);
+                return wrap(() ->engineService.registerPageModel(representation));
             });
         }
 

--- a/src/main/java/org/entando/kubernetes/service/digitalexchange/installable/processors/ServiceProcessor.java
+++ b/src/main/java/org/entando/kubernetes/service/digitalexchange/installable/processors/ServiceProcessor.java
@@ -6,6 +6,7 @@ import org.entando.kubernetes.model.EntandoPluginDeploymentRequest;
 import org.entando.kubernetes.model.digitalexchange.ComponentType;
 import org.entando.kubernetes.model.digitalexchange.DigitalExchangeJob;
 import org.entando.kubernetes.model.digitalexchange.DigitalExchangeJobComponent;
+import org.entando.kubernetes.model.digitalexchange.InstallableInstallResult;
 import org.entando.kubernetes.service.KubernetesService;
 import org.entando.kubernetes.service.digitalexchange.installable.ComponentProcessor;
 import org.entando.kubernetes.service.digitalexchange.installable.Installable;
@@ -67,8 +68,8 @@ public class ServiceProcessor implements ComponentProcessor {
         }
 
         @Override
-        public CompletableFuture install() {
-            return CompletableFuture.runAsync(() -> {
+        public CompletableFuture<InstallableInstallResult> install() {
+            return CompletableFuture.supplyAsync(() -> {
                 final EntandoPluginDeploymentRequest deploymentRequest = new EntandoPluginDeploymentRequest();
                 deploymentRequest.setPlugin(job.getComponentId());
                 deploymentRequest.setDbms(representation.getDbms());
@@ -79,7 +80,7 @@ public class ServiceProcessor implements ComponentProcessor {
                 deploymentRequest.setRoles(representation.getRoles());
 
                 log.info("Deploying a new service {}", deploymentRequest.getImage());
-                kubernetesService.linkPlugin(deploymentRequest);
+                return wrap(() -> kubernetesService.linkPlugin(deploymentRequest));
             });
         }
 

--- a/src/main/java/org/entando/kubernetes/service/digitalexchange/installable/processors/WidgetProcessor.java
+++ b/src/main/java/org/entando/kubernetes/service/digitalexchange/installable/processors/WidgetProcessor.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.entando.kubernetes.model.digitalexchange.ComponentType;
 import org.entando.kubernetes.model.digitalexchange.DigitalExchangeJob;
 import org.entando.kubernetes.model.digitalexchange.DigitalExchangeJobComponent;
+import org.entando.kubernetes.model.digitalexchange.InstallableInstallResult;
 import org.entando.kubernetes.service.digitalexchange.entandocore.EntandoEngineService;
 import org.entando.kubernetes.service.digitalexchange.installable.ComponentProcessor;
 import org.entando.kubernetes.service.digitalexchange.installable.Installable;
@@ -73,10 +74,10 @@ public class WidgetProcessor implements ComponentProcessor {
         }
 
         @Override
-        public CompletableFuture install() {
-            return CompletableFuture.runAsync(() -> {
+        public CompletableFuture<InstallableInstallResult> install() {
+            return CompletableFuture.supplyAsync(() -> {
                 log.info("Registering Widget {}", representation.getCode());
-                engineService.registerWidget(representation);
+                return wrap(() -> engineService.registerWidget(representation));
             });
         }
 

--- a/src/main/java/org/entando/kubernetes/service/digitalexchange/job/JobExecutionException.java
+++ b/src/main/java/org/entando/kubernetes/service/digitalexchange/job/JobExecutionException.java
@@ -1,13 +1,25 @@
 package org.entando.kubernetes.service.digitalexchange.job;
 
+import java.nio.file.Path;
+
 public class JobExecutionException extends RuntimeException {
 
-    public JobExecutionException(final String message, final Throwable throwable) {
+    private Path jobAssociatedTempPath;
+
+    public JobExecutionException(String message, Throwable throwable, Path jobAssociatedTempPath) {
         super(message, throwable);
+        this.jobAssociatedTempPath = jobAssociatedTempPath;
+    }
+
+    public JobExecutionException(final String message, final Throwable throwable) {
+        this(message, throwable, null);
     }
 
     public JobExecutionException(final String message) {
-        super(message);
+        this(message, null, null);
     }
 
+    public Path getJobAssociatedTempPath() {
+        return jobAssociatedTempPath;
+    }
 }

--- a/src/main/resources/db/changelog/changes/20190809112455-create-schema.yaml
+++ b/src/main/resources/db/changelog/changes/20190809112455-create-schema.yaml
@@ -97,7 +97,7 @@ databaseChangeLog:
                     nullable: true
               - column:
                   name: status
-                  type: integer
+                  type: TEXT
                   constraints:
                     nullable: false
               - column:
@@ -139,11 +139,11 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: status
-                  type: integer
+                  type: TEXT
                   constraints:
                     nullable: false
               - column:
                   name: component_type
-                  type: integer
+                  type: TEXT
                   constraints:
                     nullable: false

--- a/src/test/java/org/entando/kubernetes/controller/DigitalExchangeInstallTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/DigitalExchangeInstallTest.java
@@ -278,7 +278,7 @@ public class DigitalExchangeInstallTest {
         mockMvc.perform(post(String.format("%s/uninstall/todomvc", URL)))
                 .andDo(print()).andExpect(status().isOk());
 
-        waitFor(2000);
+        waitFor(5000);
 
         WireMock.verify(1, deleteRequestedFor(urlEqualTo("/entando-app/api/widgets/todomvc_widget")));
         WireMock.verify(1, deleteRequestedFor(urlEqualTo("/entando-app/api/widgets/another_todomvc_widget")));

--- a/src/test/java/org/entando/kubernetes/controller/DigitalExchangeInstallTest.java
+++ b/src/test/java/org/entando/kubernetes/controller/DigitalExchangeInstallTest.java
@@ -38,6 +38,7 @@ import org.apache.commons.io.IOUtils;
 import org.entando.kubernetes.DatabaseCleaner;
 import org.entando.kubernetes.client.K8SServiceClient;
 import org.entando.kubernetes.client.K8SServiceClientTestDouble;
+import org.entando.kubernetes.model.digitalexchange.JobStatus;
 import org.entando.kubernetes.model.link.EntandoAppPluginLink;
 import org.entando.kubernetes.service.digitalexchange.model.DigitalExchange;
 import org.entando.kubernetes.service.digitalexchange.signature.SignatureUtil;
@@ -273,7 +274,7 @@ public class DigitalExchangeInstallTest {
         mockMvc.perform(get(String.format("%s/install/todomvc", URL)))
                 .andDo(print()).andExpect(status().isOk())
                 .andExpect(jsonPath("payload.componentId").value("todomvc"))
-                .andExpect(jsonPath("payload.status").value("COMPLETED"));
+                .andExpect(jsonPath("payload.status").value(JobStatus.INSTALL_COMPLETED.toString()));
 
         mockMvc.perform(post(String.format("%s/uninstall/todomvc", URL)))
                 .andDo(print()).andExpect(status().isOk());


### PR DESCRIPTION
This branch cleans up the installation process by refactoring it and removing the `@Transactional` annotation which was blocking the read of the job/job-components statuses from the database. We want to store the status of the job/components even if an error is thrown 